### PR TITLE
Make Decks to Belong To Accounts and Make Flashcard to FlashcardData Mappings Update

### DIFF
--- a/src/main/Account.java
+++ b/src/main/Account.java
@@ -63,4 +63,43 @@ public class Account {
     public void deleteSession(Deck deck, StudySession session) {
         this.decksToSessions.get(deck).remove(session);
     }
+
+    public void updateSessionsOfDeck(Deck deck) {
+
+        List<Flashcard> flashcardList = deck.getFlashcards();
+
+        List<StudySession> listOfSessions = this.decksToSessions.get(deck);
+
+        for (StudySession session : listOfSessions) {
+            // First, check for updates needed from adding a card:
+            // Loop through flashcardList. If it is in flashcardData, move on.
+            // If it is not in flashcardData, add it to flashcardData.
+            // Second, check for updates needed from deleting a card:
+            // Loop through flashcardData. If it is in flashcardList, move on.
+            // If it is not in flashcardList, then delete it from flashcardData
+
+            Map<Flashcard, FlashcardData> flashcardToFlashcardData = session.getFlashcardData();
+
+            for (Flashcard flashcard : flashcardList) {
+                if (!session.getFlashcardData().containsKey(flashcard)) {
+                    session.flashcardData.put(flashcard, new FlashcardData(0));
+                }
+            }
+
+            for (Flashcard flashcard : flashcardToFlashcardData.keySet()) {
+                if (!flashcardList.contains(flashcard)) {
+                    flashcardToFlashcardData.remove(flashcard);
+                }
+            }
+
+        }
+
+
+
+
+
+
+
+
+    }
 }

--- a/src/main/Account.java
+++ b/src/main/Account.java
@@ -1,25 +1,37 @@
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class Account {
     private String username;
     private final String password;
     private final List<Deck> decks;
+    private final Map<Deck, List<StudySession>> decksToSessions;
 
     public Account(String username, String password, List<Deck> decks){
         this.username = username;
         this.password = password;
         this.decks = decks;
+        this.decksToSessions = new HashMap<>();
+        for (Deck deck : this.decks) {
+            decksToSessions.put(deck, new ArrayList<>());
+        }
     }
 
     public Account(String username, String password) {
         this.username = username;
         this.password = password;
         this.decks = new ArrayList<>();
+        this.decksToSessions = new HashMap<>();
     }
 
     public String getUsername() {
         return username;
+    }
+
+    public Map<Deck, List<StudySession>> getDecksToSessions() {
+        return this.decksToSessions;
     }
 
     public void setUsername(String newUsername){
@@ -32,5 +44,23 @@ public class Account {
 
     public List<Deck> getDecks() {
         return decks;
+    }
+
+    public void addDeck(Deck deck) {
+        this.decks.add(deck);
+        this.decksToSessions.put(deck, new ArrayList<>());
+    }
+
+    public void deleteDeck(Deck deck) {
+        this.decks.remove(deck);
+        this.decksToSessions.remove(deck);
+    }
+
+    public void addSession(Deck deck, StudySession session) {
+        this.decksToSessions.get(deck).add(session);
+    }
+
+    public void deleteSession(Deck deck, StudySession session) {
+        this.decksToSessions.get(deck).remove(session);
     }
 }

--- a/src/main/AccountInteractor.java
+++ b/src/main/AccountInteractor.java
@@ -23,4 +23,9 @@ public class AccountInteractor {
     public static void deleteSessionFromAccount(Account account, Deck deck, StudySession session) {
         account.deleteSession(deck, session);
     }
+
+    public static void updateSessionsOfDeck(Account account, Deck deck) {
+        account.updateSessionsOfDeck(deck);
+    }
+
 }

--- a/src/main/AccountInteractor.java
+++ b/src/main/AccountInteractor.java
@@ -1,10 +1,26 @@
 public class AccountInteractor {
 
     public static Account createAccount(String username, String password){
-        return (new Account(username, password));
+        return new Account(username, password);
     }
 
     public static boolean isCorrectPassword(Account account, String attemptedPassword) {
         return account.isCorrectPassword(attemptedPassword);
+    }
+
+    public static void addDeckToAccount(Account account, Deck deck) {
+        account.addDeck(deck);
+    }
+
+    public static void deleteDeckFromAccount(Account account, Deck deck) {
+        account.deleteDeck(deck);
+    }
+
+    public static void addSessionToAccount(Account account, Deck deck, StudySession session) {
+        account.addSession(deck, session);
+    }
+
+    public static void deleteSessionFromAccount(Account account, Deck deck, StudySession session) {
+        account.deleteSession(deck, session);
     }
 }

--- a/src/main/BasicShuffle.java
+++ b/src/main/BasicShuffle.java
@@ -1,43 +1,39 @@
+import java.util.ArrayList;
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.Map;
 
 public class BasicShuffle implements CardShuffler {
 
-    int counter = 0;
-    LinkedList<Flashcard> linkedListDeck;
+    int index = 0;
+    ArrayList<Flashcard> deckCopy;
 
     public BasicShuffle(Map<Flashcard, FlashcardData> flashcardData) {
-        // This turns an ImmutableList, which ToList returns, to a LinkedList. Don't ask me why.
-        this.linkedListDeck = new LinkedList<Flashcard>(flashcardData.keySet().stream().toList());
+        // This turns an ImmutableList, which ToList returns, to an ArrayList. Don't ask me why.
+        this.deckCopy = new ArrayList<>(flashcardData.keySet().stream().toList());
     }
 
-    @Override
     public void shuffleCards() {
-        Collections.shuffle(this.linkedListDeck);
+        Collections.shuffle(this.deckCopy);
     }
 
     @Override
     public Flashcard returnChosenFlashcard() {
-        if (counter == 0) {
-            System.out.println("First run!");
+        Flashcard chosenFlashcard;
+        if (index == 0) {
+            // System.out.println("First run!");
             shuffleCards();
-            counter += 1;
-            return linkedListDeck.getFirst();
-        } else if (counter < linkedListDeck.size()) {
-            System.out.println("Removing first and adding to last");
-            Flashcard oldFirstFlashcard = linkedListDeck.getFirst();
-            linkedListDeck.removeFirst();
-            linkedListDeck.addLast(oldFirstFlashcard);
-            counter += 1;
-            return linkedListDeck.getFirst();
-        } else { // counter == flashcardData.size()
-            System.out.println("Reached end, shuffling!");
-            Collections.shuffle(linkedListDeck);
-            counter = 1;
-            return linkedListDeck.getFirst();
+            chosenFlashcard = this.deckCopy.get(index);
+            index += 1;
+        } else if (index < this.deckCopy.size() - 1) {
+            // System.out.println("Removing first and adding to last");
+            chosenFlashcard = this.deckCopy.get(index);
+            index += 1;
+        } else { // index == flashcardData.size() - 1
+            // System.out.println("Reached end, shuffling!");
+            chosenFlashcard = this.deckCopy.get(index);
+            index = 0;
 
         }
-
+        return chosenFlashcard;
     }
 }

--- a/src/main/BasicShuffle.java
+++ b/src/main/BasicShuffle.java
@@ -34,7 +34,7 @@ public class BasicShuffle implements CardShuffler {
         } else { // counter == flashcardData.size()
             System.out.println("Reached end, shuffling!");
             Collections.shuffle(linkedListDeck);
-            counter = 0;
+            counter = 1;
             return linkedListDeck.getFirst();
 
         }

--- a/src/main/BasicShuffle.java
+++ b/src/main/BasicShuffle.java
@@ -1,0 +1,43 @@
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.Map;
+
+public class BasicShuffle implements CardShuffler {
+
+    int counter = 0;
+    LinkedList<Flashcard> linkedListDeck;
+
+    public BasicShuffle(Map<Flashcard, FlashcardData> flashcardData) {
+        // This turns an ImmutableList, which ToList returns, to a LinkedList. Don't ask me why.
+        this.linkedListDeck = new LinkedList<Flashcard>(flashcardData.keySet().stream().toList());
+    }
+
+    @Override
+    public void shuffleCards() {
+        Collections.shuffle(this.linkedListDeck);
+    }
+
+    @Override
+    public Flashcard returnChosenFlashcard() {
+        if (counter == 0) {
+            System.out.println("First run!");
+            shuffleCards();
+            counter += 1;
+            return linkedListDeck.getFirst();
+        } else if (counter < linkedListDeck.size()) {
+            System.out.println("Removing first and adding to last");
+            Flashcard oldFirstFlashcard = linkedListDeck.getFirst();
+            linkedListDeck.removeFirst();
+            linkedListDeck.addLast(oldFirstFlashcard);
+            counter += 1;
+            return linkedListDeck.getFirst();
+        } else { // counter == flashcardData.size()
+            System.out.println("Reached end, shuffling!");
+            Collections.shuffle(linkedListDeck);
+            counter = 0;
+            return linkedListDeck.getFirst();
+
+        }
+
+    }
+}

--- a/src/main/CardShuffler.java
+++ b/src/main/CardShuffler.java
@@ -1,0 +1,10 @@
+import java.util.Map;
+
+public interface CardShuffler {
+    /**
+     * Shuffles cards in a deck.
+     */
+    void shuffleCards();
+
+    Flashcard returnChosenFlashcard();
+}

--- a/src/main/DeckController.java
+++ b/src/main/DeckController.java
@@ -18,16 +18,22 @@ public class DeckController {
         DeckInteractor.renameDeck(deck, newName);
     }
 
-    public void addCard(Deck deck, Flashcard.Front front, String back){
+    public void addCard(Account account, Deck deck, Flashcard.Front front, String back){
         DeckInteractor.addFlashcard(deck, front, back);
+        updateSessionsOfDeck(account, deck);
     }
 
-    public void deleteCard(Deck deck, Flashcard flashcard){
+    public void deleteCard(Account account, Deck deck, Flashcard flashcard){
         DeckInteractor.deleteFlashcard(deck, flashcard);
+        updateSessionsOfDeck(account, deck);
     }
 
     public Flashcard.Front createFront(String text, Image image) {
         return DeckInteractor.createFront(text, image);
+    }
+
+    public void updateSessionsOfDeck(Account account, Deck deck) {
+        AccountInteractor.updateSessionsOfDeck(account, deck);
     }
 
 }

--- a/src/main/DeckController.java
+++ b/src/main/DeckController.java
@@ -1,6 +1,4 @@
 import java.awt.*;
-import java.util.ArrayList;
-import java.util.List;
 
 public class DeckController {
 

--- a/src/main/DeckController.java
+++ b/src/main/DeckController.java
@@ -3,20 +3,17 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class DeckController {
-    public List<Deck> decks;
 
-    public DeckController(List<Deck> decks){
-        this.decks = decks;
-    }
+    public DeckController() {}
 
-    public DeckController(){
-        this.decks = new ArrayList<>();
-    }
-
-    public Deck createDeck(String name){
+    public Deck createDeck(String name, Account account){
         Deck deck = DeckInteractor.createDeck(name);
-        decks.add(deck);
+        AccountInteractor.addDeckToAccount(account, deck);
         return deck;
+    }
+
+    public void deleteDeck(Deck deck, Account account) {
+        AccountInteractor.deleteDeckFromAccount(account, deck);
     }
 
     public void renameDeck(Deck deck, String newName){
@@ -27,12 +24,12 @@ public class DeckController {
         DeckInteractor.addFlashcard(deck, front, back);
     }
 
-    public Flashcard.Front createFront(String text, Image image) {
-        return DeckInteractor.createFront(text, image);
-    }
-
     public void deleteCard(Deck deck, Flashcard flashcard){
         DeckInteractor.deleteFlashcard(deck, flashcard);
+    }
+
+    public Flashcard.Front createFront(String text, Image image) {
+        return DeckInteractor.createFront(text, image);
     }
 
 }

--- a/src/main/FlashcardData.java
+++ b/src/main/FlashcardData.java
@@ -1,0 +1,60 @@
+public class FlashcardData {
+    private int proficiency;
+    private int cardsUntilDue;
+    private int consecutiveCorrects;
+    private int consecutiveIncorrects;
+    private boolean isSeen;
+
+    public FlashcardData(int defaultCardsUntilDue) {
+        this.isSeen = false;
+        this.proficiency = 0;
+        this.cardsUntilDue = defaultCardsUntilDue;
+        this.consecutiveCorrects = 0;
+        this.consecutiveIncorrects = 0;
+    }
+
+    public boolean getIsSeen() {
+        return this.isSeen;
+    }
+
+    public int getProficiency() {
+        return proficiency;
+    }
+
+    public int getCardsUntilDue() {
+        return cardsUntilDue;
+    }
+
+    public int getConsecutiveCorrects() {
+        return consecutiveCorrects;
+    }
+
+    public int getConsecutiveIncorrects() {
+        return consecutiveIncorrects;
+    }
+
+    public void setCardsUntilDue(int newCardsUntilDue) {
+        this.cardsUntilDue = newCardsUntilDue;
+    }
+
+    public void resetConsecutiveCorrects() {
+        this.consecutiveCorrects = 0;
+    }
+
+    public void resetConsecutiveIncorrects() {
+        this.consecutiveIncorrects = 0;
+    }
+
+    public void incrementConsecutiveCorrects() {
+        this.consecutiveCorrects += 1;
+    }
+
+    public void incrementConsecutiveIncorrects() {
+        this.consecutiveIncorrects += 1;
+    }
+
+    public void incrementProficiency(int delta) {
+        this.proficiency += delta;
+    }
+
+}

--- a/src/main/FlashcardSystem.java
+++ b/src/main/FlashcardSystem.java
@@ -5,6 +5,7 @@ public class FlashcardSystem {
     private final SessionController sessionController = new SessionController();
     private final SessionPresenter sessionPresenter = new SessionPresenter();
     private final Scanner scanner = new Scanner(System.in);
+    private final Account account = AccountInteractor.createAccount("User", "Pass");
 
     public void displayMainMenu() {
         String select;
@@ -31,7 +32,7 @@ public class FlashcardSystem {
 
     private Deck displayDecks() {
         //TODO: change format to (0) Back (1) Deck 1 (2) Deck 2 ....
-        List<Deck> decks = deckController.decks;
+        List<Deck> decks = account.getDecks();
         for (int i=0; i<decks.size(); i++) {
             System.out.println("("+i+") Deck "+ decks.get(i).getName());
         }
@@ -64,7 +65,7 @@ public class FlashcardSystem {
         String select = scanner.nextLine();
         //TODO: check for invalid input
         if (select.equals("0")) {
-            return sessionController.createPracticeSession(deck);
+            return sessionController.getPracticeSession(deck, account);
         }
         // TODO: remove once invalid input is properly handled
         return null;
@@ -73,7 +74,7 @@ public class FlashcardSystem {
     private void displayCreateDeckMenu() {
         System.out.println("Name of New Deck:");
         String name = scanner.nextLine();
-        deckController.createDeck(name);
+        deckController.createDeck(name, account);
     }
 
     private void displayEditDeckMenu() {

--- a/src/main/FlashcardSystem.java
+++ b/src/main/FlashcardSystem.java
@@ -114,7 +114,7 @@ public class FlashcardSystem {
         Flashcard.Front front = deckController.createFront(frontInput, null);
         System.out.println("Back of card:");
         String back = scanner.nextLine();
-        deckController.addCard(deck, front, back);
+        deckController.addCard(account, deck, front, back);
     }
 
     private void displayEditCardMenu(Deck deck) {
@@ -134,7 +134,7 @@ public class FlashcardSystem {
                 //TODO: edit front
                 break;
             case "3":
-                deckController.deleteCard(deck, card);
+                deckController.deleteCard(account, deck, card);
                 break;
         }
     }

--- a/src/main/PracticeSession.java
+++ b/src/main/PracticeSession.java
@@ -10,25 +10,18 @@ public class PracticeSession extends StudySession {
      */
     public PracticeSession(Deck deck) {
         super(deck);
-        this.proficiencies = new HashMap<>();
+        this.flashcardData = new HashMap<>();
         this.deck = deck;
         for (Flashcard card : this.deck.getFlashcards()) {
-            this.proficiencies.put(card, 0);
+            this.flashcardData.put(card, new FlashcardData(0));
         }
+        this.cardshuffler = new BasicShuffle(this.flashcardData);
     }
 
-    /**
-     * Randomly pick a new card from this PracticeSession's deck to show to the user.
-     * Assume that this.deck.flashcards is non-empty. The empty case should be
-     * handled by the SessionController before calling this method.
-     * @return Return a randomly chosen Flashcard from this PracticeSession's deck.
-     */
     @Override
     public Flashcard getNextCard() {
-        Random random = new Random();
-        // nextInt takes an exclusive right bound, so rand_index takes from [0, flashcards.size() - 1]
-        int rand_index = random.nextInt(this.deck.getFlashcards().size());
-        return this.deck.getFlashcards().get(rand_index);
+        return this.cardshuffler.returnChosenFlashcard();
     }
+
 
 }

--- a/src/main/SessionController.java
+++ b/src/main/SessionController.java
@@ -1,4 +1,3 @@
-import java.util.ArrayList;
 import java.util.List;
 
 public class SessionController {

--- a/src/main/SessionController.java
+++ b/src/main/SessionController.java
@@ -2,46 +2,30 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class SessionController {
-    private List<StudySession> sessions;
-    private StudySession recent;
 
-    public SessionController() {
-        this.sessions = new ArrayList<>();
+    public SessionController() {}
+
+    // TODO: createSession for every type
+    public StudySession getPracticeSession(Deck deck, Account account) {
+        List<StudySession> sessions = account.getDecksToSessions().get(deck);
+        StudySession existingSession = getExistingSameSession(sessions, PracticeSession.class);
+        // if session already exists, resume it, else, create a new session
+        if (existingSession == null) {
+            StudySession newSession = SessionInteractor.createPracticeSession(deck);
+            AccountInteractor.addSessionToAccount(account, deck, newSession);
+            return newSession;
+        } else {
+            return existingSession;
+        }
     }
 
-    public StudySession createPracticeSession(Deck deck) {
-        // TODO: createSession for every type
-        StudySession session = SessionInteractor.createPracticeSession(deck);
-        sessions.add(session);
-        recent = session;
-        return recent;
-    }
-
-    // name of session if they want to resume a specific session
-    public StudySession resumeSession(String name) {
-        for (StudySession studySession : this.sessions) {
-            if (studySession.name.equals(name)) {
-                recent = studySession;
-                return studySession;
+    private StudySession getExistingSameSession(List<StudySession> sessions, Class<? extends StudySession> sessionClass) {
+        for (StudySession session : sessions) {
+            if (sessionClass.isInstance(session)) {
+                return session;
             }
         }
-        return resumeSession();
-    }
-
-    // resume recent session if they do not specify, if no recent choose last one created, if no options throw error
-    public StudySession resumeSession() {
-        if (recent != null){
-            return recent;
-        }
-        else if (this.sessions.size() == 0){
-           // TODO throw an error
-            return null;
-        }
-        else {
-            StudySession session = this.sessions.get(this.sessions.size() - 1);
-            recent = session;
-            return session;
-        }
+        return null;
     }
 
     public Flashcard getNextCard(StudySession session) {

--- a/src/main/SessionInteractor.java
+++ b/src/main/SessionInteractor.java
@@ -8,10 +8,10 @@ public class SessionInteractor {
 
     // if they get the card right, add one to proficiency
     // TODO: Move this method into StudySession implementers to be customized by calling session.adjustProficiency()
-    public static void adjustProficiency(StudySession session, Flashcard flashcard) {
-        int currProficiency = session.getProficiencies().get(flashcard);
-        session.getProficiencies().put(flashcard, currProficiency + 1);
-    }
+//    public static void adjustProficiency(StudySession session, Flashcard flashcard) {
+//        int currProficiency = session.getProficiencies().get(flashcard);
+//        session.getProficiencies().put(flashcard, currProficiency + 1);
+//    }
 
     public static Flashcard getNextCard(StudySession session) {
         return session.getNextCard();

--- a/src/main/SessionInteractor.java
+++ b/src/main/SessionInteractor.java
@@ -1,7 +1,6 @@
 public class SessionInteractor {
 
-    private SessionInteractor() {
-    }
+    private SessionInteractor() {}
 
     public static StudySession createPracticeSession(Deck deck) {
         return new PracticeSession(deck);

--- a/src/main/StudySession.java
+++ b/src/main/StudySession.java
@@ -9,6 +9,7 @@ public abstract class StudySession {
     protected Map<Flashcard, FlashcardData> flashcardData = new HashMap<>();
     protected String name;
     protected int currentCard;
+    protected CardShuffler cardshuffler;
 
     public StudySession(Deck deck, String name) {
         this.deck = deck;

--- a/src/main/StudySession.java
+++ b/src/main/StudySession.java
@@ -6,7 +6,7 @@ import java.util.Map;
 public abstract class StudySession {
     // TODO consider changing some of these private
     protected Deck deck;
-    protected Map<Flashcard, Integer> proficiencies = new HashMap<>();
+    protected Map<Flashcard, FlashcardData> flashcardData = new HashMap<>();
     protected String name;
     protected int currentCard;
 
@@ -26,12 +26,13 @@ public abstract class StudySession {
         Collections.shuffle(this.deck.getFlashcards());
         currentCard = 0;
     }
-    public Map<Flashcard, Integer> getProficiencies(){
-        return proficiencies;
-    }
 
     public int getCurrentCard(){
         return currentCard;
+    }
+
+    public Map<Flashcard, FlashcardData> getFlashcardData() {
+        return this.flashcardData;
     }
 
 }

--- a/src/test/DeckControllerTest.java
+++ b/src/test/DeckControllerTest.java
@@ -5,17 +5,18 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class DeckControllerTest {
     DeckController deckController;
+    Deck deck;
     Account account;
 
     @BeforeEach
     void setUp() {
         deckController = new DeckController();
+        deck = deckController.createDeck("Deck Name", account);
         account = AccountInteractor.createAccount("user1", "pass1");
     }
 
     @Test
     void addCard() {
-        Deck deck = deckController.createDeck("Deck Name");
         Flashcard.Front front = deckController.createFront("front", null);
         deckController.addCard(deck, front, "back");
         // TODO: check if card exists in account's Deck-StudySession proficiency map
@@ -24,7 +25,6 @@ public class DeckControllerTest {
 
     @Test
     void deleteCard() {
-        Deck deck = deckController.createDeck("Deck Name");
         Flashcard.Front front = deckController.createFront("front", null);
         deckController.addCard(deck, front, "back");
         deckController.deleteCard(deck, deck.getFlashcards().get(0));
@@ -33,15 +33,17 @@ public class DeckControllerTest {
 
     @Test
     void renameDeck() {
-        Deck deck = deckController.createDeck("Deck Name");
         deckController.renameDeck(deck, "New name");
         assertEquals("New name", deck.getName());
     }
 
     @Test
     void createDeck() {
-        Deck deck = deckController.createDeck("Deck Name");
-        // TODO: check if account has deck
-        assertTrue(deckController.decks.contains(deck));
+        assertTrue(account.getDecks().contains(deck));
+    }
+
+    @Test
+    void deleteDeck() {
+        assertFalse(account.getDecks().contains(deck));
     }
 }

--- a/src/test/DeckControllerTest.java
+++ b/src/test/DeckControllerTest.java
@@ -18,7 +18,7 @@ public class DeckControllerTest {
     @Test
     void addCard() {
         Flashcard.Front front = deckController.createFront("front", null);
-        deckController.addCard(deck, front, "back");
+        deckController.addCard(account, deck, front, "back");
         // TODO: check if card exists in account's Deck-StudySession proficiency map
         assertEquals(1, deck.getFlashcards().size());
     }
@@ -26,8 +26,8 @@ public class DeckControllerTest {
     @Test
     void deleteCard() {
         Flashcard.Front front = deckController.createFront("front", null);
-        deckController.addCard(deck, front, "back");
-        deckController.deleteCard(deck, deck.getFlashcards().get(0));
+        deckController.addCard(account, deck, front, "back");
+        deckController.deleteCard(account, deck, deck.getFlashcards().get(0));
         assertEquals(0, deck.getFlashcards().size());
     }
 


### PR DESCRIPTION
This pull request migrates Decks to belong to Accounts, creates a FlashcardData class to encapsulate proficiency and other related flashcard info, and create a mapping of Deck to a list of StudySessions mapping in each Account, as well as implements some added functionality to Accounts as a bonus. In addition, because the Flashcard to FlashcardData mappings in each StudySession cannot know when a new flashcard is added or deleted from the Deck, every time a Deck is updated, we need to update each StudySession that uses that Deck to reflect the change. This pull request takes a first stab at this problem.

Credit to @Ixstreme for the migration of the ownership of Decks and StudySessions to Account.