### PR TITLE
Remove Entities from outer layers using DTOs

### DIFF
--- a/src/main/java/Accounts/Account.java
+++ b/src/main/java/Accounts/Account.java
@@ -31,6 +31,19 @@ public class Account {
     }
 
     /**
+     * Create a new Account with the given username, password, and list of decks.
+     * @param username Username of the account
+     * @param password Password of the account
+     * @param decks Starting decks of the account
+     */
+    public Account(String username, String password, List<Deck> decks, Map<Deck, List<StudySession>> decksToSessions) {
+        this.username = username;
+        this.password = password;
+        this.decks = decks;
+        this.decksToSessions = decksToSessions;
+    }
+
+    /**
      * Create a new Account with the given username and password, and an empty list of decks.
      * @param username Username of the account
      * @param password Password of the account
@@ -55,6 +68,13 @@ public class Account {
      */
     public void setUsername(String username) {
         this.username = username;
+    }
+
+    /**
+     * @return This account's password
+     */
+    public String getPassword() {
+        return password;
     }
 
     /**
@@ -113,6 +133,7 @@ public class Account {
      * @param session The session which will be deleted from this account
      */
     public void deleteSession(Deck deck, StudySession session) {
+
         this.decksToSessions.get(deck).remove(session);
     }
 }

--- a/src/main/java/Accounts/Account.java
+++ b/src/main/java/Accounts/Account.java
@@ -133,7 +133,6 @@ public class Account {
      * @param session The session which will be deleted from this account
      */
     public void deleteSession(Deck deck, StudySession session) {
-
         this.decksToSessions.get(deck).remove(session);
     }
 }

--- a/src/main/java/Accounts/AccountDTO.java
+++ b/src/main/java/Accounts/AccountDTO.java
@@ -1,0 +1,55 @@
+package Accounts;
+
+import Decks.Deck;
+import Decks.DeckDTO;
+import Decks.DeckInteractor;
+import Sessions.StudySession;
+import Sessions.StudySessionDTO;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class AccountDTO {
+
+    private final String username;
+    private final String password;
+    private final List<DeckDTO> decks;
+    private final Map<DeckDTO, List<StudySessionDTO>> decksToSessions;
+
+    public AccountDTO(String username, String password, List<DeckDTO> decks, Map<DeckDTO,
+            List<StudySessionDTO>> decksToSessions) {
+        this.username = username;
+        this.password = password;
+        this.decks = decks;
+        this.decksToSessions = decksToSessions;
+    }
+
+    /**
+     * @return this account's username
+     */
+    public String getUsername() {
+        return username;
+    }
+
+    /**
+     * @return this account's password
+     */
+    public String getPassword() {
+        return password;
+    }
+
+    /**
+     * @return this account's decks
+     */
+    public List<DeckDTO> getDecks() {
+        return decks;
+    }
+
+    /**
+     * @return a mapping from a deck to its sessions owned by this account
+     */
+    public Map<DeckDTO, List<StudySessionDTO>> getDecksToSessions() {
+        return decksToSessions;
+    }
+}

--- a/src/main/java/Accounts/AccountDTO.java
+++ b/src/main/java/Accounts/AccountDTO.java
@@ -1,12 +1,8 @@
 package Accounts;
 
-import Decks.Deck;
 import Decks.DeckDTO;
-import Decks.DeckInteractor;
-import Sessions.StudySession;
 import Sessions.StudySessionDTO;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 

--- a/src/main/java/Accounts/AccountInteractor.java
+++ b/src/main/java/Accounts/AccountInteractor.java
@@ -130,6 +130,21 @@ public class AccountInteractor {
     }
 
     /**
+     * Get the StudySessions linked to the given deck.
+     * @param deckDTO the deck whose sessions will be fetched
+     * @return a List of StudySessionDTOs
+     */
+    public static List<StudySessionDTO> getSessionsOfDeck(DeckDTO deckDTO) {
+        Deck deck = findDeckInCurrentAccountFromDTO(deckDTO);
+        List<StudySession> sessions = currentAccount.getDecksToSessions().get(deck);
+        List<StudySessionDTO> sessionDTOs = new ArrayList<>();
+        for (StudySession s : sessions) {
+            sessionDTOs.add(SessionInteractor.convertSessionToDTO(s));
+        }
+        return sessionDTOs;
+    }
+
+    /**
      * Adds or deletes flashcards in the flashcard-to-data mapping of each StudySession to match the current state of
      * the specified deck. Should be called when a card is added or deleted from a deck.
      * @param deckDTO The deck which has had cards added or deleted

--- a/src/main/java/Accounts/AccountInteractor.java
+++ b/src/main/java/Accounts/AccountInteractor.java
@@ -1,94 +1,145 @@
 package Accounts;
 
 import Decks.Deck;
+import Decks.DeckDTO;
+import Decks.DeckInteractor;
 import Flashcards.Flashcard;
 import Flashcards.FlashcardData;
+import Sessions.SessionInteractor;
 import Sessions.StudySession;
+import Sessions.StudySessionDTO;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 public class AccountInteractor {
 
+    private static Account currentAccount;
+
     private AccountInteractor() {}
 
     /**
-     * Create and return a new user account.
-     * @param username This account's identifying username.
-     * @param password This account's password.
-     * @return a new Account.
+     * Attempt to log in to the given account. Return whether the login was successful.
+     * @param accountDTO The target account
+     * @param attemptedPassword The password used to attempt a login
+     * @return whether login was successful
      */
-    public static Account createAccount(String username, String password){
-        return new Account(username, password);
+    public static boolean login(AccountDTO accountDTO, String attemptedPassword) {
+        Account account = convertDTOToAccount(accountDTO);
+        if (account.isCorrectPassword(attemptedPassword)) {
+            currentAccount = account;
+            return true;
+        } else {
+            return false;
+        }
     }
 
     /**
-     * Change this account's username to the given username.
-     * @param account The target account
-     * @param newUsername The new username of the account
+     * Provide relevant interactors with the ability to use the given deck.
      */
-    public static void changeUsername(Account account, String newUsername) {
-        account.setUsername(newUsername);
+    public static void selectDeck(DeckDTO selectedDeckDTO) {
+        Deck currentDeck = findDeckInCurrentAccountFromDTO(selectedDeckDTO);
+        DeckInteractor.setCurrentDeck(currentDeck);
+    }
+
+    /**
+     * Provide relevant interactors with the ability to use the given StudySession.
+     */
+    public static void selectSession(DeckDTO deckDTO, StudySessionDTO sessionDTO) {
+        Deck currentDeck = findDeckInCurrentAccountFromDTO(deckDTO);
+        StudySession currentSession = findSessionInCurrentAccountFromDTO(currentDeck, sessionDTO);
+        SessionInteractor.setCurrentSession(currentSession);
+    }
+
+    /**
+     * @return the current account
+     */
+    public static AccountDTO getCurrentAccount() {
+        return convertAccountToDTO(currentAccount);
     }
 
     /**
      * Return whether the attempted password matches the account's true password.
-     * @param account The targeted account for login
+     * @param accountDTO The targeted account for login
      * @param attemptedPassword The attempted password
      * @return whether the attempted password matches the account's true password.
      */
-    public static boolean isCorrectPassword(Account account, String attemptedPassword) {
+    public static boolean isCorrectPassword(AccountDTO accountDTO, String attemptedPassword) {
+        Account account = convertDTOToAccount(accountDTO);
         return account.isCorrectPassword(attemptedPassword);
     }
 
     /**
-     * Add a new deck to this account.
-     * @param account The target account
-     * @param deck The deck to be added
+     * Create and return an AccountDTO.
+     * @param username This account's identifying username.
+     * @param password This account's password.
+     * @return a new AccountDTO.
      */
-    public static void addDeckToAccount(Account account, Deck deck) {
-        account.addDeck(deck);
+    public static AccountDTO createAccount(String username, String password) {
+        Account account = new Account(username, password);
+        return convertAccountToDTO(account);
+    }
+
+    /**
+     * Change the current account's username to the given username.
+     * @param newUsername The new username of the account
+     */
+    public static void changeCurrentAccountUsername(String newUsername) {
+        currentAccount.setUsername(newUsername);
+    }
+
+    /**
+     * Add a new deck to the account.
+     * @param deckDTO The deck to be added
+     */
+    public static void addDeckToCurrentAccount(DeckDTO deckDTO) {
+        Deck deck = DeckInteractor.convertDTOToDeck(deckDTO);
+        currentAccount.addDeck(deck);
     }
 
     /**
      * Delete an existing deck from this account.
-     * @param account The target account
-     * @param deck The deck to be deleted
+     * @param deckDTO The deck to be deleted
      */
-    public static void deleteDeckFromAccount(Account account, Deck deck) {
-        account.deleteDeck(deck);
+    public static void deleteDeckFromCurrentAccount(DeckDTO deckDTO) {
+        Deck deck = findDeckInCurrentAccountFromDTO(deckDTO);
+        currentAccount.getDecks().remove(deck);
     }
 
     /**
      * Add a new StudySession on a deck to this account.
-     * @param account The target account
-     * @param deck The deck to which the StudySession is based on
-     * @param session The added StudySession
+     * @param deckDTO The deck to which the StudySession is based on
+     * @param sessionDTO The added StudySession
      */
-    public static void addSessionToAccount(Account account, Deck deck, StudySession session) {
-        account.addSession(deck, session);
+    public static void addSessionToCurrentAccount(DeckDTO deckDTO, StudySessionDTO sessionDTO) {
+        Deck deck = findDeckInCurrentAccountFromDTO(deckDTO);
+        currentAccount.addSession(deck, SessionInteractor.convertDTOToSession(sessionDTO));
     }
 
     /**
-     * Delete an existing StudySession on a deck from this account.
-     * @param account The target account
-     * @param deck The deck to which the StudySession is based on
-     * @param session The StudySession to be deleted
+     * Delete an existing StudySession on a deck from the current account.
+     * @param deckDTO The deck to which the StudySession is based on
+     * @param sessionDTO The StudySession to be deleted
      */
-    public static void deleteSessionFromAccount(Account account, Deck deck, StudySession session) {
-        account.deleteSession(deck, session);
+    public static void deleteSessionFromCurrentAccount(DeckDTO deckDTO, StudySessionDTO sessionDTO) {
+        Deck deck = findDeckInCurrentAccountFromDTO(deckDTO);
+        StudySession session = findSessionInCurrentAccountFromDTO(deck, sessionDTO);
+        currentAccount.deleteSession(deck, session);
     }
 
     /**
      * Adds or deletes flashcards in the flashcard-to-data mapping of each StudySession to match the current state of
      * the specified deck. Should be called when a card is added or deleted from a deck.
-     * @param account The target account
-     * @param deck The deck which has had cards added or deleted
+     * @param deckDTO The deck which has had cards added or deleted
      */
-    public static void updateSessionsOfDeck(Account account, Deck deck) {
+    public static void updateSessionsOfDeckInCurrentAccount(DeckDTO deckDTO) {
+        Deck deck = findDeckInCurrentAccountFromDTO(deckDTO);
+
         List<Flashcard> flashcardList = deck.getFlashcards();
 
-        List<StudySession> listOfSessions = account.getDecksToSessions().get(deck);
+        List<StudySession> listOfSessions = currentAccount.getDecksToSessions().get(deck);
 
         for (StudySession session : listOfSessions) {
             // First, check for updates needed from adding a card:
@@ -113,6 +164,57 @@ public class AccountInteractor {
             }
             session.updateDeckContext();
         }
+    }
+
+    public static Account convertDTOToAccount(AccountDTO accountDTO) {
+        String username = accountDTO.getUsername();
+        String password = accountDTO.getPassword();
+        List<Deck> decks = new ArrayList<>();
+        Map<Deck, List<StudySession>> decksToSessions = new HashMap<>();
+        for (DeckDTO deckDTO : accountDTO.getDecks()) {
+            Deck deck = DeckInteractor.convertDTOToDeck(deckDTO);
+            decks.add(deck);
+            List<StudySession> sessions = new ArrayList<>();
+            for (StudySessionDTO sessionDTO : accountDTO.getDecksToSessions().get(deckDTO)) {
+                StudySession session = SessionInteractor.convertDTOToSession(sessionDTO);
+                sessions.add(session);
+            }
+            decksToSessions.put(deck, sessions);
+        }
+        return new Account(username, password, decks, decksToSessions);
+    }
+
+    public static AccountDTO convertAccountToDTO(Account account) {
+        String username = account.getUsername();
+        String password = account.getPassword();
+        List<DeckDTO> decksDTO = new ArrayList<>();
+        Map<DeckDTO, List<StudySessionDTO>> decksToSessionsDTO = new HashMap<>();
+        for (Deck deck : account.getDecks()) {
+            DeckDTO deckDTO = DeckInteractor.convertDeckToDTO(deck);
+            decksDTO.add(deckDTO);
+            List<StudySessionDTO> sessionsDTO = new ArrayList<>();
+            for (StudySession session : account.getDecksToSessions().get(deck)) {
+                StudySessionDTO sessionDTO = SessionInteractor.convertSessionToDTO(session);
+                sessionsDTO.add(sessionDTO);
+            }
+            decksToSessionsDTO.put(deckDTO, sessionsDTO);
+        }
+        return new AccountDTO(username, password, decksDTO, decksToSessionsDTO);
+    }
+
+    private static Deck findDeckInCurrentAccountFromDTO(DeckDTO deckDTO) {
+        return currentAccount.getDecks().stream()
+                .filter(d -> d.getName().equals(deckDTO.getName()))
+                .findAny()
+                .orElse(null);
+    }
+
+    private static StudySession findSessionInCurrentAccountFromDTO(Deck deck, StudySessionDTO sessionDTO) {
+        StudySession selectedSession = SessionInteractor.convertDTOToSession(sessionDTO);
+        return currentAccount.getDecksToSessions().get(deck).stream()
+                .filter(session -> session.getClass().equals(selectedSession.getClass()))
+                .findAny()
+                .orElse(null);
     }
 
 }

--- a/src/main/java/Decks/DeckController.java
+++ b/src/main/java/Decks/DeckController.java
@@ -2,14 +2,14 @@ package Decks;
 
 import Accounts.AccountDTO;
 import Accounts.AccountInteractor;
-import Database.DataBaseGateway;
+//import Database.DataBaseGateway;
 import Flashcards.FlashcardDTO;
 
 import java.awt.*;
 import java.util.ArrayList;
 import java.util.List;
 
-public class DeckController implements DataBaseGateway {
+public class DeckController { //implements DataBaseGateway {
 
     public DeckController() {}
 
@@ -23,10 +23,9 @@ public class DeckController implements DataBaseGateway {
 
     /**
      * Provide relevant interactors with the ability to use the flashcard at this index.
-     * @param flashcardDTO The selected flashcard which will be worked on.
+     * @param index The index of the selected flashcard which will be worked on in the current deck.
      */
-    public void selectFlashcard(FlashcardDTO flashcardDTO) {
-        int index = getCurrentDeck().getFlashcards().indexOf(flashcardDTO);
+    public void selectFlashcard(int index) {
         DeckInteractor.selectFlashcard(index);
     }
 
@@ -43,7 +42,7 @@ public class DeckController implements DataBaseGateway {
             return false;
         }
         AccountInteractor.addDeckToCurrentAccount(deckDTO);
-        addDeckToDB(account, name);
+        //addDeckToDB(account, name);
         return true;
     }
 
@@ -53,7 +52,7 @@ public class DeckController implements DataBaseGateway {
      */
     public void deleteDeck(DeckDTO deckDTO) {
         AccountInteractor.deleteDeckFromCurrentAccount(deckDTO);
-        deleteDeckInDB(account, deck.getName());
+        //deleteDeckInDB(account, deck.getName());
     }
 
     /**
@@ -67,14 +66,13 @@ public class DeckController implements DataBaseGateway {
 
     /**
      * Delete a flashcard from the current deck. Also deletes the card from the database.
-     * @param flashcardDTO The flashcard to be deleted
+     * @param index The index of the flashcard to be deleted in the current deck
      */
-    public void deleteCard(FlashcardDTO flashcardDTO) {
-        int index = getCurrentDeck().getFlashcards().indexOf(flashcardDTO);
+    public void deleteCard(int index) {
         DeckInteractor.deleteFlashcardFromCurrentDeck(index);
         AccountInteractor.updateSessionsOfDeckInCurrentAccount(getCurrentDeck());
 
-        deleteCardInDB(account, deck.getName(), flashcard.getFront().getText(), flashcard.getBack());
+        //deleteCardInDB(account, deck.getName(), flashcard.getFront().getText(), flashcard.getBack());
     }
 
     /**

--- a/src/main/java/Decks/DeckController.java
+++ b/src/main/java/Decks/DeckController.java
@@ -1,75 +1,103 @@
 package Decks;
 
 import Accounts.Account;
+import Accounts.AccountDTO;
 import Accounts.AccountInteractor;
 import Database.DataBaseGateway;
 import Flashcards.Flashcard;
+import Flashcards.FlashcardDTO;
+import Flashcards.FlashcardInteractor;
 
 import java.awt.*;
+import java.util.ArrayList;
+import java.util.List;
 
 public class DeckController implements DataBaseGateway {
 
     public DeckController() {}
 
     /**
-     * Create and return a new empty deck, which is bound to the specified account and stored in a database.
-     * @param account The account to add the new deck to
-     * @param name Name of the new deck
-     * @return the new deck.
+     * Get a DTO representation of the selected deck.
+     * @return a DeckDTO
      */
-    public Deck createDeck(Account account, String name){
-        Deck deck = DeckInteractor.createDeck(name);
-        addDeckToDB(account, name);
-        AccountInteractor.addDeckToAccount(account, deck);
-        return deck;
+    public DeckDTO getCurrentDeck() {
+        return DeckInteractor.getCurrentDeck();
     }
 
     /**
-     * Delete an existing deck from the specified account. Also deletes the deck from the database.
-     * @param account The account to delete the deck from
-     * @param deck The deck to be deleted
+     * Provide relevant interactors with the ability to use the flashcard at this index.
+     * @param flashcardDTO The selected flashcard which will be worked on.
      */
-    public void deleteDeck(Account account, Deck deck) {
-        AccountInteractor.deleteDeckFromAccount(account, deck);
+    public void selectFlashcard(FlashcardDTO flashcardDTO) {
+        int index = getCurrentDeck().getFlashcards().indexOf(flashcardDTO);
+        DeckInteractor.selectFlashcard(index);
+    }
+
+    /**
+     * Create a new empty deck, which is bound to the current account and stored in a database. Return whether the
+     * deck was successfully created.
+     * @param name Name of the new deck
+     * @return whether the deck was successfully created
+     */
+    public boolean createDeck(String name){
+        DeckDTO deckDTO = DeckInteractor.createDeck(name);
+        AccountDTO accountDTO = AccountInteractor.getCurrentAccount();
+        if (!hasUniqueName(deckDTO, accountDTO)) {
+            return false;
+        }
+        AccountInteractor.addDeckToCurrentAccount(deckDTO);
+        addDeckToDB(account, name);
+        return true;
+    }
+
+    /**
+     * Delete an existing deck from the current account. Also deletes the deck from the database.
+     * @param deckDTO The deck to be deleted
+     */
+    public void deleteDeck(DeckDTO deckDTO) {
+        AccountInteractor.deleteDeckFromCurrentAccount(deckDTO);
         deleteDeckInDB(account, deck.getName());
     }
 
     /**
-     * Rename an existing deck. Also renames the deck in the database.
-     * @param deck The deck to be renamed
+     * Rename the current deck. Also renames the deck in the database.
      * @param newName The new name of the deck
      */
-    public void renameDeck(Deck deck, String newName){
+    public void renameCurrentDeck(String newName) {
+        DeckInteractor.renameCurrentDeck(newName);
         //updateRowInDB("decks", "deck_name", deck.getName(), newName);
-        DeckInteractor.renameDeck(deck, newName);
     }
 
     /**
-     * Delete a flashcard from the specified deck. Also deletes the card from the database.
-     * @param account The target account
-     * @param deck The deck which owns the flashcard
-     * @param flashcard The flashcard to be deleted
+     * Delete a flashcard from the current deck. Also deletes the card from the database.
+     * @param flashcardDTO The flashcard to be deleted
      */
-    public void deleteCard(Account account, Deck deck, Flashcard flashcard){
-        DeckInteractor.deleteFlashcard(deck, flashcard);
+    public void deleteCard(FlashcardDTO flashcardDTO) {
+        int index = getCurrentDeck().getFlashcards().indexOf(flashcardDTO);
+        DeckInteractor.deleteFlashcardFromCurrentDeck(index);
+        AccountInteractor.updateSessionsOfDeckInCurrentAccount(getCurrentDeck());
+
         deleteCardInDB(account, deck.getName(), flashcard.getFront().getText(), flashcard.getBack());
-        AccountInteractor.updateSessionsOfDeck(account, deck);
     }
 
     /**
      * Add a new flashcard to the specified deck. Also adds the card to the database.
-     * @param account The target account
-     * @param deck The deck which will own the flashcard
      * @param frontText The text on the front of the new flashcard (possibly null)
      * @param frontImage The image on the front of the new flashcard (possibly null)
      * @param back The text on the back of the new flashcard
      */
-    public void addCard(Account account, Deck deck, String frontText, Image frontImage, String back) {
-        DeckInteractor.addFlashcard(deck, frontText, frontImage, back);
+    public void addCard(String frontText, Image frontImage, String back) {
+        DeckInteractor.addFlashcardToCurrentDeck(frontText, frontImage, back);
+        AccountInteractor.updateSessionsOfDeckInCurrentAccount(getCurrentDeck());
 //        addCardToDeckInDB(account, deck.getName(), frontText, back, );
-        AccountInteractor.updateSessionsOfDeck(account, deck);
     }
 
-
+    private boolean hasUniqueName(DeckDTO deckDTO, AccountDTO accountDTO) {
+        List<String> existingDeckNames = new ArrayList<>();
+        for (DeckDTO d : accountDTO.getDecks()) {
+            existingDeckNames.add(d.getName());
+        }
+        return !existingDeckNames.contains(deckDTO.getName());
+    }
 
 }

--- a/src/main/java/Decks/DeckController.java
+++ b/src/main/java/Decks/DeckController.java
@@ -1,12 +1,9 @@
 package Decks;
 
-import Accounts.Account;
 import Accounts.AccountDTO;
 import Accounts.AccountInteractor;
 import Database.DataBaseGateway;
-import Flashcards.Flashcard;
 import Flashcards.FlashcardDTO;
-import Flashcards.FlashcardInteractor;
 
 import java.awt.*;
 import java.util.ArrayList;

--- a/src/main/java/Decks/DeckDTO.java
+++ b/src/main/java/Decks/DeckDTO.java
@@ -1,10 +1,7 @@
 package Decks;
 
-import Flashcards.Flashcard;
 import Flashcards.FlashcardDTO;
-import Flashcards.FlashcardInteractor;
 
-import java.util.ArrayList;
 import java.util.List;
 
 public class DeckDTO {

--- a/src/main/java/Decks/DeckDTO.java
+++ b/src/main/java/Decks/DeckDTO.java
@@ -1,0 +1,26 @@
+package Decks;
+
+import Flashcards.Flashcard;
+import Flashcards.FlashcardDTO;
+import Flashcards.FlashcardInteractor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class DeckDTO {
+    private final String name;
+    private final List<FlashcardDTO> flashcards;
+
+    public DeckDTO(String name, List<FlashcardDTO> flashcards) {
+        this.name = name;
+        this.flashcards = flashcards;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public List<FlashcardDTO> getFlashcards() {
+        return flashcards;
+    }
+}

--- a/src/main/java/Decks/DeckInteractor.java
+++ b/src/main/java/Decks/DeckInteractor.java
@@ -1,49 +1,106 @@
 package Decks;
 
 import Flashcards.Flashcard;
+import Flashcards.FlashcardDTO;
 import Flashcards.FlashcardInteractor;
 
 import java.awt.*;
+import java.util.ArrayList;
+import java.util.List;
 
 public class DeckInteractor {
 
+    private static Deck currentDeck;
+
+    private DeckInteractor() {}
+
     /**
-     * Create and return a new deck.
+     * Set the current deck for this interactor to work on and mutate.
+     * @param deck the deck that will be worked on by this interactor.
+     */
+    public static void setCurrentDeck(Deck deck) {
+        currentDeck = deck;
+    }
+
+    /**
+     * Provide relevant interactors with the ability to use the flashcard at this index.
+     * @param index The index of the flashcard within the current deck
+     */
+    public static void selectFlashcard(int index) {
+        FlashcardInteractor.setCurrentFlashcard(currentDeck.getFlashcards().get(index));
+    }
+
+    /**
+     * @return the current deck
+     */
+    public static DeckDTO getCurrentDeck() {
+        return convertDeckToDTO(currentDeck);
+    }
+
+    /**
+     * Create a new deck. Return the DTO representation of the created deck.
      * @param deckName The name of the new deck
      * @return the created deck.
      */
-    public static Deck createDeck(String deckName) {
-        return new Deck(deckName);
+    public static DeckDTO createDeck(String deckName) {
+        Deck deck = new Deck(deckName);
+        return convertDeckToDTO(deck);
     }
 
     /**
-     * Rename the specified deck.
-     * @param deck The deck to be renamed
+     * Rename the current deck.
      * @param newName The new name of the deck
      */
-    public static void renameDeck(Deck deck, String newName) {
-        deck.setName(newName);
+    public static void renameCurrentDeck(String newName) {
+        currentDeck.setName(newName);
     }
 
     /**
-     * Delete a flashcard from the specified deck.
-     * @param deck The deck which owns the flashcard to be deleted
-     * @param flashcard The flashcard to be deleted
+     * Delete a flashcard from the current deck.
+     * @param index The index of the flashcard to be deleted
      */
-    public static void deleteFlashcard(Deck deck, Flashcard flashcard) {
-        deck.removeFlashcard(flashcard);
+    public static void deleteFlashcardFromCurrentDeck(int index) {
+        currentDeck.getFlashcards().remove(index);
     }
 
     /**
-     * Add a new flashcard to the specified deck.
-     * @param deck The deck which will own the new flashcard
+     * Add a new flashcard to the current deck.
      * @param frontText The text on the front of the new flashcard (possibly null)
      * @param frontImage The image on the front of the new flashcard (possibly null)
      * @param back The text on the back of the new flashcard
      */
-    public static void addFlashcard(Deck deck, String frontText, Image frontImage, String back) {
-        Flashcard newFlashcard = FlashcardInteractor.createFlashcard(frontText, frontImage, back);
-        deck.addFlashcard(newFlashcard);
+    public static void addFlashcardToCurrentDeck(String frontText, Image frontImage, String back) {
+        FlashcardDTO newFlashcard = FlashcardInteractor.createFlashcard(frontText, frontImage, back);
+        currentDeck.addFlashcard(FlashcardInteractor.convertDTOToFlashcard(newFlashcard));
+    }
+
+    /**
+     * Get a Deck entity from its DTO representation.
+     * @param deckDTO The target deck
+     * @return a Deck
+     */
+    public static Deck convertDTOToDeck(DeckDTO deckDTO) {
+        List<Flashcard> flashcards = new ArrayList<>();
+        for (FlashcardDTO flashcardDTO : deckDTO.getFlashcards()) {
+            Flashcard flashcard = FlashcardInteractor.convertDTOToFlashcard(flashcardDTO);
+            flashcards.add(flashcard);
+        }
+        return new Deck(deckDTO.getName(), flashcards);
+    }
+
+    /**
+     * Get a DTO representation of the specified deck.
+     * @param deck The target deck
+     * @return a DeckDTO
+     */
+    public static DeckDTO convertDeckToDTO(Deck deck) {
+        String name = deck.getName();
+        List<FlashcardDTO> flashcardsDTO = new ArrayList<>();
+        for (Flashcard flashcard : deck.getFlashcards()) {
+            FlashcardDTO flashcardDTO = FlashcardInteractor.convertFlashcardToDTO(flashcard);
+            flashcardsDTO.add(flashcardDTO);
+        }
+        return new DeckDTO(name, flashcardsDTO);
     }
 
 }

--- a/src/main/java/FlashcardProgram/SessionPresenter.java
+++ b/src/main/java/FlashcardProgram/SessionPresenter.java
@@ -1,8 +1,8 @@
 package FlashcardProgram;
 
-import Flashcards.Flashcard;
+import Flashcards.FlashcardDTO;
 import Sessions.SessionController;
-import Sessions.StudySession;
+import Sessions.StudySessionDTO;
 
 import java.util.Scanner;
 
@@ -25,21 +25,22 @@ public class SessionPresenter {
      * @param session The current StudySession for which we are displaying cards.
      * @param exitChar The String that the user types when they want to exit the StudySession.
      */
-    public void displaySession(StudySession session, String exitChar) {
-        Flashcard card;
+    public void displaySession(StudySessionDTO session, String exitChar) {
+        FlashcardDTO card;
         String userInput;
+        // We assume that the session was already started properly by the previous controller...
         System.out.println("Beginning session...");
         do {
             System.out.println("Retrieving new card...");
-            card = sessionController.getNextCard(session);
+            card = sessionController.getNextCard();
             displayFlashcardFront(card);
             String answer = getUserInput("Please input anything to see the back.");
             displayFlashcardBack(card);
             if (card.getBack().equalsIgnoreCase(answer)) {
-                sessionController.postAnswerUpdate(session, true);
+                sessionController.postAnswerUpdate(true);
                 System.out.println("You got the answer right!");
             } else {
-                sessionController.postAnswerUpdate(session, false);
+                sessionController.postAnswerUpdate(false);
                 System.out.println("You got the answer wrong!");
             }
             userInput = getUserInput("Would you like to see another card? If not, please input \"" + exitChar + "\", " +
@@ -52,8 +53,8 @@ public class SessionPresenter {
      *
      * @param card The flashcard whose front is displayed.
      */
-    private void displayFlashcardFront(Flashcard card) {
-        System.out.println("Front: " + card.getFront().getText());
+    private void displayFlashcardFront(FlashcardDTO card) {
+        System.out.println("Front: " + card.getFrontText());
     }
 
     /**
@@ -61,7 +62,7 @@ public class SessionPresenter {
      *
      * @param card The flashcard whose back is displayed.
      */
-    private void displayFlashcardBack(Flashcard card) {
+    private void displayFlashcardBack(FlashcardDTO card) {
         System.out.println("Back: " + card.getBack());
     }
 

--- a/src/main/java/Flashcards/FlashcardDTO.java
+++ b/src/main/java/Flashcards/FlashcardDTO.java
@@ -1,0 +1,35 @@
+package Flashcards;
+
+import java.awt.*;
+
+public class FlashcardDTO {
+
+    private final Flashcard.Front front;
+    private final String back;
+
+    public FlashcardDTO(Flashcard.Front front, String back) {
+        this.front = front;
+        this.back = back;
+    }
+
+    /**
+     * @return the String on the front of this Flashcard
+     */
+    public String getFrontText() {
+        return front.getText();
+    }
+
+    /**
+     * @return the Image on the front of this Flashcard
+     */
+    public Image getFrontImage() {
+        return front.getImage();
+    }
+
+    /**
+     * @return the String on the back of this Flashcard
+     */
+    public String getBack() {
+        return this.back;
+    }
+}

--- a/src/main/java/Flashcards/FlashcardData.java
+++ b/src/main/java/Flashcards/FlashcardData.java
@@ -13,6 +13,16 @@ public class FlashcardData {
         this.cardsUntilDue = defaultCardsUntilDue;
     }
 
+    /**
+     * Construct a new FlashcardData instance, which contains raw statistics for a Flashcard in a StudySession.
+     * @param proficiency The proficiency of this flashcard
+     * @param defaultCardsUntilDue Default cardsUntilDue, customizable for the needs of a StudySession.
+     */
+    public FlashcardData(int proficiency, int defaultCardsUntilDue) {
+        this.proficiency = proficiency;
+        this.cardsUntilDue = defaultCardsUntilDue;
+    }
+
     public int getProficiency() {
         return proficiency;
     }

--- a/src/main/java/Flashcards/FlashcardDataDTO.java
+++ b/src/main/java/Flashcards/FlashcardDataDTO.java
@@ -1,0 +1,20 @@
+package Flashcards;
+
+public class FlashcardDataDTO {
+
+    private final int proficiency;
+    private final int cardsUntilDue;
+
+    public FlashcardDataDTO(int proficiency, int cardsUntilDue) {
+        this.proficiency = proficiency;
+        this.cardsUntilDue = cardsUntilDue;
+    }
+
+    public int getProficiency() {
+        return proficiency;
+    }
+
+    public int getCardsUntilDue() {
+        return cardsUntilDue;
+    }
+}

--- a/src/main/java/Flashcards/FlashcardInteractor.java
+++ b/src/main/java/Flashcards/FlashcardInteractor.java
@@ -1,41 +1,93 @@
 package Flashcards;
 
-import java.awt.*;
+import java.awt.Image;
 
 public class FlashcardInteractor {
+
+    private static Flashcard currentFlashcard;
 
     private FlashcardInteractor() {}
 
     /**
-     * Construct and return a new Flashcard.
+     * Set the current flashcard for this interactor to work on and mutate.
+     * @param flashcard the flashcard that will be worked on by this interactor.
+     */
+    public static void setCurrentFlashcard(Flashcard flashcard) {
+        currentFlashcard = flashcard;
+    }
+
+    /**
+     * @return the current flashcard
+     */
+    public static FlashcardDTO getCurrentFlashcard() {
+        return convertFlashcardToDTO(currentFlashcard);
+    }
+
+    /**
+     * Construct and return a new FlashcardDTO.
      * @param frontText The text of the front of the new Flashcard to be returned (possibly null)
      * @param frontImage The image of the front of the new Flashcard to be returned (possibly null)
      * @param back The back of the new Flashcard to be returned
      * @return The Flashcard with front and back specified in the args
      */
-    public static Flashcard createFlashcard(String frontText, Image frontImage, String back) {
+    public static FlashcardDTO createFlashcard(String frontText, Image frontImage, String back) {
         Flashcard.Front front = new Flashcard.Front(frontText, frontImage);
-        return new Flashcard(front, back);
+        return new FlashcardDTO(front, back);
     }
 
     /**
-     * Edit the front of a Flashcard.
-     * @param flashcard The Flashcard to be edited
+     * Edit the front of the current flashcard.
      * @param frontText The new text of the front of the Flashcard (possibly null)
      * @param frontImage The new image of the front of the Flashcard (possibly null)
      */
-    public static void editFront(Flashcard flashcard, String frontText, Image frontImage) {
+    public static void editCurrentFlashcardFront(String frontText, Image frontImage) {
         Flashcard.Front front = new Flashcard.Front(frontText, frontImage);
-        flashcard.setFront(front);
+        currentFlashcard.setFront(front);
     }
 
     /**
-     * Edit the back of a Flashcard.
-     * @param flashcard The Flashcard to be edited
+     * Edit the back of the current flashcard.
      * @param newBack The new back that will replace the current one
      */
-    public static void editBack(Flashcard flashcard, String newBack) {
-        flashcard.setBack(newBack);
+    public static void editCurrentFlashcardBack(String newBack) {
+        currentFlashcard.setBack(newBack);
+    }
+
+    /**
+     * Get a DTO representation of the specified flashcard.
+     * @param flashcard The target flashcard
+     * @return a FlashcardDTO
+     */
+    public static FlashcardDTO convertFlashcardToDTO(Flashcard flashcard) {
+        return new FlashcardDTO(flashcard.getFront(), flashcard.getBack());
+    }
+
+    /**
+     * Get a Flashcard entity from its DTO representation.
+     * @param flashcardDTO The target flashcard
+     * @return a Flashcard
+     */
+    public static Flashcard convertDTOToFlashcard(FlashcardDTO flashcardDTO) {
+        Flashcard.Front front = new Flashcard.Front(flashcardDTO.getFrontText(), flashcardDTO.getFrontImage());
+        return new Flashcard(front, flashcardDTO.getBack());
+    }
+
+    /**
+     * Get a DTO representation of the specified FlashcardData.
+     * @param data The target FlashcardData
+     * @return a FlashcardDataDTO
+     */
+    public static FlashcardDataDTO convertFlashcardDataToDTO(FlashcardData data) {
+        return new FlashcardDataDTO(data.getProficiency(), data.getCardsUntilDue());
+    }
+
+    /**
+     * Get a FlashcardData entity from its DTO representation.
+     * @param dataDTO The target FlashcardData
+     * @return a FlashcardData
+     */
+    public static FlashcardData convertDTOToFlashcardData(FlashcardDataDTO dataDTO) {
+        return new FlashcardData(dataDTO.getProficiency(), dataDTO.getCardsUntilDue());
     }
 
 }

--- a/src/main/java/Main/Main.java
+++ b/src/main/java/Main/Main.java
@@ -4,11 +4,11 @@ import FlashcardProgram.FlashcardSystem;
 
 public class Main {
     public static void main(String[] args) {
-//        FlashcardSystem fs = new FlashcardSystem();
-//        fs.displayMainMenu();
+        FlashcardSystem fs = new FlashcardSystem();
+        fs.displayMainMenu();
         // TODO: properly use modules instead of this hack for JavaFX
-        //LearningSessionUI.main(args);
-        UI.MainUI.main(args);
+        // LearningSessionUI.main(args);
+        // UI.MainUI.main(args);
 
     }
 }

--- a/src/main/java/Sessions/BasicShuffle.java
+++ b/src/main/java/Sessions/BasicShuffle.java
@@ -8,8 +8,8 @@ import java.util.*;
 
 public class BasicShuffle extends CardShuffler {
 
-    int index = 0;
-    ArrayList<Flashcard> deckCopy;
+    private int index;
+    private List<Flashcard> deckCopy;
 
     /**
      * Construct a new BasicShuffle card shuffler.
@@ -17,6 +17,7 @@ public class BasicShuffle extends CardShuffler {
      */
     public BasicShuffle(Map<Flashcard, FlashcardData> flashcardToData) {
         // This turns an ImmutableList, which ToList returns, to an ArrayList. Don't ask me why.
+        this.index = 0;
         this.deckCopy = new ArrayList<>(flashcardToData.keySet().stream().toList());
         this.flashcardToData = flashcardToData;
     }
@@ -34,10 +35,30 @@ public class BasicShuffle extends CardShuffler {
     }
 
     /**
+     * Construct a new BasicShuffle shuffler.
+     * @param flashcardToData A mapping from Flashcard to FlashcardData taken from this shuffler's StudySession.
+     * @param deckCopy A list of flashcards which were copied from the original deck
+     * @param index The index of the deck where the next card will be pulled from.
+     */
+    public BasicShuffle(Map<Flashcard, FlashcardData> flashcardToData, List<Flashcard> deckCopy, int index) {
+        this.index = index;
+        this.flashcardToData = flashcardToData;
+        this.deckCopy = deckCopy;
+    }
+
+    /**
      * Randomly shuffles this shuffler's deckCopy to a random order.
      */
     public void shuffleCards() {
         Collections.shuffle(this.deckCopy);
+    }
+
+    public int getIndex() {
+        return index;
+    }
+
+    public List<Flashcard> getDeckCopy() {
+        return deckCopy;
     }
 
     /**

--- a/src/main/java/Sessions/BasicShuffleDTO.java
+++ b/src/main/java/Sessions/BasicShuffleDTO.java
@@ -1,8 +1,6 @@
 package Sessions;
 
-import Flashcards.Flashcard;
 import Flashcards.FlashcardDTO;
-import Flashcards.FlashcardData;
 import Flashcards.FlashcardDataDTO;
 
 import java.util.List;

--- a/src/main/java/Sessions/BasicShuffleDTO.java
+++ b/src/main/java/Sessions/BasicShuffleDTO.java
@@ -1,0 +1,30 @@
+package Sessions;
+
+import Flashcards.Flashcard;
+import Flashcards.FlashcardDTO;
+import Flashcards.FlashcardData;
+import Flashcards.FlashcardDataDTO;
+
+import java.util.List;
+import java.util.Map;
+
+public class BasicShuffleDTO extends CardShufflerDTO {
+
+    private final int index;
+    private final List<FlashcardDTO> deckCopy;
+
+    public BasicShuffleDTO(Map<FlashcardDTO, FlashcardDataDTO> flashcardToData,
+                           List<FlashcardDTO> deckCopy, int index) {
+        super(flashcardToData);
+        this.index = index;
+        this.deckCopy = deckCopy;
+    }
+
+    public int getIndex() {
+        return index;
+    }
+
+    public List<FlashcardDTO> getDeckCopy() {
+        return deckCopy;
+    }
+}

--- a/src/main/java/Sessions/CardShufflerDTO.java
+++ b/src/main/java/Sessions/CardShufflerDTO.java
@@ -1,0 +1,21 @@
+package Sessions;
+
+import Flashcards.Flashcard;
+import Flashcards.FlashcardDTO;
+import Flashcards.FlashcardData;
+import Flashcards.FlashcardDataDTO;
+
+import java.util.Map;
+
+public abstract class CardShufflerDTO {
+
+    Map<FlashcardDTO, FlashcardDataDTO> flashcardToData;
+
+    public CardShufflerDTO(Map<FlashcardDTO, FlashcardDataDTO> flashcardToData) {
+        this.flashcardToData = flashcardToData;
+    }
+
+    Map<FlashcardDTO, FlashcardDataDTO> getFlashcardToData() {
+        return this.flashcardToData;
+    }
+}

--- a/src/main/java/Sessions/CardShufflerDTO.java
+++ b/src/main/java/Sessions/CardShufflerDTO.java
@@ -1,8 +1,6 @@
 package Sessions;
 
-import Flashcards.Flashcard;
 import Flashcards.FlashcardDTO;
-import Flashcards.FlashcardData;
 import Flashcards.FlashcardDataDTO;
 
 import java.util.Map;

--- a/src/main/java/Sessions/LearningSession.java
+++ b/src/main/java/Sessions/LearningSession.java
@@ -10,6 +10,14 @@ public class LearningSession extends StudySession {
      */
     public LearningSession(Deck deck) {
         super(deck, new SmartShuffle(deck));
-        this.deck = deck;
+    }
+
+    /**
+     * Construct a new LearningSession
+     * @param deck A deck that will be bound to this LearningSession.
+     * @param cardShuffler The card shuffler algorithm used by this session.
+     */
+    public LearningSession(Deck deck, CardShuffler cardShuffler) {
+        super(deck, cardShuffler);
     }
 }

--- a/src/main/java/Sessions/LearningSessionDTO.java
+++ b/src/main/java/Sessions/LearningSessionDTO.java
@@ -1,0 +1,10 @@
+package Sessions;
+
+import Decks.DeckDTO;
+
+public class LearningSessionDTO extends StudySessionDTO {
+
+    public LearningSessionDTO(DeckDTO deckDTO, CardShufflerDTO smartShuffleDTO) {
+        super(deckDTO, smartShuffleDTO);
+    }
+}

--- a/src/main/java/Sessions/PracticeSession.java
+++ b/src/main/java/Sessions/PracticeSession.java
@@ -1,8 +1,6 @@
 package Sessions;
 
 import Decks.Deck;
-import Sessions.BasicShuffle;
-import Sessions.StudySession;
 
 public class PracticeSession extends StudySession {
     /**

--- a/src/main/java/Sessions/PracticeSession.java
+++ b/src/main/java/Sessions/PracticeSession.java
@@ -11,7 +11,14 @@ public class PracticeSession extends StudySession {
      */
     public PracticeSession(Deck deck) {
         super(deck, new BasicShuffle(deck));
-        this.deck = deck;
-        this.cardShuffler = new BasicShuffle(deck);
+    }
+
+    /**
+     * Construct a PracticeSession with all FlashcardData initialized to default values.
+     * @param deck The deck that this session will use to show cards to the user.
+     * @param cardShuffler The card shuffler strategy used by this session.
+     */
+    public PracticeSession(Deck deck, CardShuffler cardShuffler) {
+        super(deck, cardShuffler);
     }
 }

--- a/src/main/java/Sessions/PracticeSessionDTO.java
+++ b/src/main/java/Sessions/PracticeSessionDTO.java
@@ -1,0 +1,10 @@
+package Sessions;
+
+import Decks.DeckDTO;
+
+public class PracticeSessionDTO extends StudySessionDTO {
+
+    public PracticeSessionDTO(DeckDTO deckDTO, CardShufflerDTO basicShuffleDTO) {
+        super(deckDTO, basicShuffleDTO);
+    }
+}

--- a/src/main/java/Sessions/SessionController.java
+++ b/src/main/java/Sessions/SessionController.java
@@ -2,7 +2,10 @@ package Sessions;
 import Accounts.Account;
 import Accounts.AccountInteractor;
 import Decks.Deck;
+import Decks.DeckDTO;
+import Decks.DeckInteractor;
 import Flashcards.Flashcard;
+import Flashcards.FlashcardDTO;
 
 import java.util.List;
 
@@ -10,75 +13,76 @@ public class SessionController {
 
     public SessionController() {}
 
+    /**
+     * Get a DTO representation of the selected StudySession.
+     * @return a DeckDTO
+     */
+    public StudySessionDTO getCurrentSession() {
+        return SessionInteractor.getCurrentSession();
+    }
+
     // TODO: createSession for every type
     /**
-     * Either get an existing PracticeSession or create a new one if a PracticeSession does not already exist in the
+     * Either start an existing PracticeSession or create a new one if a PracticeSession does not already exist in the
      * specified account.
-     * @param deck The deck which this PracticeSession is based on
-     * @param account The target account
-     * @return a PracticeSession
+     * @param deckDTO The deck which this PracticeSession is based on
      */
-    public StudySession getPracticeSession(Deck deck, Account account) {
-        List<StudySession> sessions = account.getDecksToSessions().get(deck);
-        StudySession existingSession = getExistingSameSession(sessions, PracticeSession.class);
+    public void startPracticeSession(DeckDTO deckDTO) {
+        List<StudySessionDTO> sessions = AccountInteractor.getCurrentAccount().getDecksToSessions().get(deckDTO);
+        StudySessionDTO existingSession = getExistingSameSession(sessions, PracticeSessionDTO.class);
         // if session already exists, resume it, else, create a new session
         if (existingSession == null) {
-            StudySession newSession = SessionInteractor.createPracticeSession(deck);
-            AccountInteractor.addSessionToAccount(account, deck, newSession);
-            return newSession;
+            StudySessionDTO newSession = SessionInteractor.createPracticeSession(deckDTO);
+            AccountInteractor.addSessionToCurrentAccount(deckDTO, newSession);
+            AccountInteractor.selectSession(deckDTO, newSession);
         } else {
-            return existingSession;
+            AccountInteractor.selectSession(deckDTO, existingSession);
         }
     }
 
     /**
-     * Either get an existing LearningSession or create a new one if a LearningSession does not already exist in the
+     * Either start an existing LearningSession or create a new one if a LearningSession does not already exist in the
      * specified account.
-     * @param deck The deck which this LearningSession is based on
-     * @param account The target account
-     * @return a LearningSession
+     * @param deckDTO The deck which this LearningSession is based on
      */
-    public StudySession getLearningSession(Deck deck, Account account) {
-        List<StudySession> sessions = account.getDecksToSessions().get(deck);
-        StudySession existingSession = getExistingSameSession(sessions, LearningSession.class);
+    public void startLearningSession(DeckDTO deckDTO) {
+        List<StudySessionDTO> sessions = AccountInteractor.getCurrentAccount().getDecksToSessions().get(deckDTO);
+        StudySessionDTO existingSession = getExistingSameSession(sessions, LearningSessionDTO.class);
         // if session already exists, resume it, else, create a new session
         if (existingSession == null) {
-            StudySession newSession = SessionInteractor.createLearningSession(deck);
-            AccountInteractor.addSessionToAccount(account, deck, newSession);
-            return newSession;
+            StudySessionDTO newSession = SessionInteractor.createLearningSession(deckDTO);
+            AccountInteractor.addSessionToCurrentAccount(deckDTO, newSession);
+            AccountInteractor.selectSession(deckDTO, newSession);
         } else {
-            return existingSession;
+            AccountInteractor.selectSession(deckDTO, existingSession);
         }
     }
 
     /**
      * Delete the specified StudySession from the specified account.
-     * @param session The StudySession to be deleted
-     * @param deck The deck which the session is based on
-     * @param account The target account
+     * @param deckDTO The deck which the session is based on
+     * @param sessionDTO The StudySession to be deleted
      */
-    public void deleteSession(StudySession session, Deck deck, Account account) {
-        AccountInteractor.deleteSessionFromAccount(account, deck, session);
+    public void deleteSession(DeckDTO deckDTO, StudySessionDTO sessionDTO) {
+        AccountInteractor.deleteSessionFromCurrentAccount(deckDTO, sessionDTO);
     }
 
     /**
      * Return the next card that should be shown to the user in the specified StudySession.
-     * @param session The StudySession which will provide cards to the user
-     * @return a Flashcard
+     * @return a FlashcardDTO
      */
-    public Flashcard getNextCard(StudySession session) {
+    public FlashcardDTO getNextCard() {
         // TODO: throw an exception if the deck is empty
-        return SessionInteractor.getNextCard(session);
+        return SessionInteractor.getNextCard();
     }
 
     /**
      * Update the StudySession's algorithmic metrics on the user's performance on the previous card guess.
      * This will influence what cards the StudySession will give to the user in the future.
-     * @param session The StudySession which is being run
      * @param wasCorrect Whether the user guessed the back of the flashcard correctly
      */
-    public void postAnswerUpdate(StudySession session, boolean wasCorrect) {
-        SessionInteractor.postAnswerUpdate(session, wasCorrect);
+    public void postAnswerUpdate(boolean wasCorrect) {
+        SessionInteractor.postAnswerUpdate(wasCorrect);
     }
 
     /**
@@ -88,8 +92,9 @@ public class SessionController {
      * @param sessionClass The desired type of StudySession
      * @return a StudySession of type sessionClass if it exists, otherwise, null
      */
-    private StudySession getExistingSameSession(List<StudySession> sessions, Class<? extends StudySession> sessionClass) {
-        for (StudySession session : sessions) {
+    private StudySessionDTO getExistingSameSession(List<StudySessionDTO> sessions,
+                                                   Class<? extends StudySessionDTO> sessionClass) {
+        for (StudySessionDTO session : sessions) {
             if (sessionClass.isInstance(session)) {
                 return session;
             }

--- a/src/main/java/Sessions/SessionController.java
+++ b/src/main/java/Sessions/SessionController.java
@@ -25,7 +25,7 @@ public class SessionController {
      * @param deckDTO The deck which this PracticeSession is based on
      */
     public void startPracticeSession(DeckDTO deckDTO) {
-        List<StudySessionDTO> sessions = AccountInteractor.getCurrentAccount().getDecksToSessions().get(deckDTO);
+        List<StudySessionDTO> sessions = AccountInteractor.getSessionsOfDeck(deckDTO);
         StudySessionDTO existingSession = getExistingSameSession(sessions, PracticeSessionDTO.class);
         // if session already exists, resume it, else, create a new session
         if (existingSession == null) {
@@ -43,7 +43,7 @@ public class SessionController {
      * @param deckDTO The deck which this LearningSession is based on
      */
     public void startLearningSession(DeckDTO deckDTO) {
-        List<StudySessionDTO> sessions = AccountInteractor.getCurrentAccount().getDecksToSessions().get(deckDTO);
+        List<StudySessionDTO> sessions = AccountInteractor.getSessionsOfDeck(deckDTO);
         StudySessionDTO existingSession = getExistingSameSession(sessions, LearningSessionDTO.class);
         // if session already exists, resume it, else, create a new session
         if (existingSession == null) {

--- a/src/main/java/Sessions/SessionController.java
+++ b/src/main/java/Sessions/SessionController.java
@@ -1,10 +1,7 @@
 package Sessions;
-import Accounts.Account;
+
 import Accounts.AccountInteractor;
-import Decks.Deck;
 import Decks.DeckDTO;
-import Decks.DeckInteractor;
-import Flashcards.Flashcard;
 import Flashcards.FlashcardDTO;
 
 import java.util.List;

--- a/src/main/java/Sessions/SessionInteractor.java
+++ b/src/main/java/Sessions/SessionInteractor.java
@@ -1,53 +1,197 @@
 package Sessions;
 
 import Decks.Deck;
-import Flashcards.Flashcard;
+import Decks.DeckDTO;
+import Decks.DeckInteractor;
+import Flashcards.*;
 import Sessions.LearningSession;
 import Sessions.PracticeSession;
 import Sessions.StudySession;
 import Sessions.UpdatingShuffler;
+import jdk.incubator.vector.VectorOperators;
+
+import java.util.*;
 
 public class SessionInteractor {
+
+    private static StudySession currentSession;
 
     private SessionInteractor() {}
 
     /**
+     * Set the current StudySession for this interactor to work on and mutate.
+     * @param session the session that will be worked on by this interactor.
+     */
+    public static void setCurrentSession(StudySession session) {
+        currentSession = session;
+    }
+
+    /**
      * Return a new PracticeSession based on the specified deck.
-     * @param deck The deck which this session will be based on
+     * @param deckDTO The deck which this session will be based on
      * @return a new PracticeSession.
      */
-    public static StudySession createPracticeSession(Deck deck) {
-        return new PracticeSession(deck);
+    public static StudySessionDTO createPracticeSession(DeckDTO deckDTO) {
+        return convertSessionToDTO(new PracticeSession(DeckInteractor.convertDTOToDeck(deckDTO)));
     }
 
     /**
      * Return a new LearningSession based on the specified deck.
-     * @param deck The deck which this session will be based on
+     * @param deckDTO The deck which this session will be based on
      * @return a new LearningSession.
      */
-    public static StudySession createLearningSession(Deck deck) {
-        return new LearningSession(deck);
+    public static StudySessionDTO createLearningSession(DeckDTO deckDTO) {
+        return convertSessionToDTO(new LearningSession(DeckInteractor.convertDTOToDeck(deckDTO)));
     }
 
     /**
-     * Return the next card that should be shown to the user in the specified StudySession.
-     * @param session The StudySession which will provide cards to the user
-     * @return a Flashcard
+     * @return the current session
      */
-    public static Flashcard getNextCard(StudySession session) {
-        return session.getNextCard();
+    public static StudySessionDTO getCurrentSession() {
+        return convertSessionToDTO(currentSession);
     }
 
     /**
-     * Update the StudySession's algorithmic metrics on the user's performance on the previous card guess.
+     * Return the next card that should be shown to the user in the current StudySession.
+     * @return a FlashcardDTO
+     */
+    public static FlashcardDTO getNextCard() {
+        return FlashcardInteractor.convertFlashcardToDTO(currentSession.getNextCard());
+    }
+
+    /**
+     * Update the current StudySession's algorithmic metrics on the user's performance on the previous card guess.
      * This will influence what cards the StudySession will give to the user in the future if the StudySession uses
      * a complex card-shuffling algorithm.
-     * @param session The StudySession which is being run
      * @param wasCorrect Whether the user guessed the back of the flashcard correctly
      */
-    public static void postAnswerUpdate(StudySession session, boolean wasCorrect) {
-        if (session.cardShuffler instanceof UpdatingShuffler) {
-            ((UpdatingShuffler) session.cardShuffler).postAnswerFlashcardDataUpdate(wasCorrect);
+    public static void postAnswerUpdate(boolean wasCorrect) {
+        if (currentSession.getCardShuffler() instanceof UpdatingShuffler) {
+            ((UpdatingShuffler) currentSession.getCardShuffler()).postAnswerFlashcardDataUpdate(wasCorrect);
+        }
+    }
+
+    /**
+     * Get a StudySession entity from its DTO representation.
+     * @param sessionDTO The target StudySession
+     * @return a StudySession
+     */
+    public static StudySession convertDTOToSession(StudySessionDTO sessionDTO) {
+        if (sessionDTO instanceof PracticeSessionDTO practiceSessionDTO) {
+            Deck deck = DeckInteractor.convertDTOToDeck(practiceSessionDTO.getDeckDTO());
+            CardShuffler cardShuffler = convertDTOToShuffler(practiceSessionDTO.getCardShufflerDTO());
+            return new PracticeSession(deck, cardShuffler);
+        } else if (sessionDTO instanceof LearningSessionDTO learningSessionDTO) {
+            Deck deck = DeckInteractor.convertDTOToDeck(learningSessionDTO.getDeckDTO());
+            CardShuffler cardShuffler = convertDTOToShuffler(learningSessionDTO.getCardShufflerDTO());
+            return new LearningSession(deck, cardShuffler);
+        } else if (sessionDTO instanceof TestSessionDTO testSessionDTO){
+            Deck deck = DeckInteractor.convertDTOToDeck(testSessionDTO.getDeckDTO());
+            CardShuffler cardShuffler = convertDTOToShuffler(testSessionDTO.getCardShufflerDTO());
+            int length = testSessionDTO.getLength();
+            int cardsSeen = testSessionDTO.getCardsSeen();
+            int numCorrect = testSessionDTO.getNumCorrect();
+            return new TestSession(deck, cardShuffler, length, cardsSeen, numCorrect);
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Get a DTO representation of the specified StudySession.
+     * @param session The target StudySession
+     * @return a StudySessionDTO
+     */
+    public static StudySessionDTO convertSessionToDTO(StudySession session) {
+        if (session instanceof PracticeSession practiceSession) {
+            DeckDTO deckDTO = DeckInteractor.convertDeckToDTO(practiceSession.getDeck());
+            CardShufflerDTO shufflerDTO = convertShufflerToDTO(practiceSession.getCardShuffler());
+            return new PracticeSessionDTO(deckDTO, shufflerDTO);
+        } else if (session instanceof LearningSession learningSession) {
+            DeckDTO deckDTO = DeckInteractor.convertDeckToDTO(learningSession.getDeck());
+            CardShufflerDTO shufflerDTO = convertShufflerToDTO(learningSession.getCardShuffler());
+            return new LearningSessionDTO(deckDTO, shufflerDTO);
+        } else if (session instanceof TestSession testSession) {
+            DeckDTO deckDTO = DeckInteractor.convertDeckToDTO(testSession.getDeck());
+            CardShufflerDTO shufflerDTO = convertShufflerToDTO(testSession.getCardShuffler());
+            int length = testSession.getLength();
+            int cardsSeen = testSession.getCardsSeen();
+            int numCorrect = testSession.getNumCorrect();
+            return new TestSessionDTO(deckDTO, shufflerDTO, length, cardsSeen, numCorrect);
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Get a DTO representation of the specified CardShuffler.
+     * @param shuffler The target StudySession
+     * @return a CardShufflerDTO
+     */
+    public static CardShufflerDTO convertShufflerToDTO(CardShuffler shuffler) {
+        if (shuffler instanceof BasicShuffle basicShuffle) {
+            Map<FlashcardDTO, FlashcardDataDTO> flashcardToDataDTO = new HashMap<>();
+            List<FlashcardDTO> deckCopy = new ArrayList<>();
+            for (Flashcard flashcard : basicShuffle.getDeckCopy()) {
+                FlashcardDTO flashcardDTO = FlashcardInteractor.convertFlashcardToDTO(flashcard);
+                FlashcardDataDTO dataDTO = FlashcardInteractor.convertFlashcardDataToDTO(
+                        basicShuffle.flashcardToData.get(flashcard));
+                deckCopy.add(flashcardDTO);
+                flashcardToDataDTO.put(flashcardDTO, dataDTO);
+            }
+            int index = basicShuffle.getIndex();
+            return new BasicShuffleDTO(flashcardToDataDTO, deckCopy, index);
+        } else if (shuffler instanceof SmartShuffle smartShuffle) {
+            Map<FlashcardDTO, FlashcardDataDTO> flashcardToDataDTO = new HashMap<>();
+            LinkedList<FlashcardDTO> deckCopy = new LinkedList<>();
+            for (Flashcard flashcard : smartShuffle.getDeckCopy()) {
+                FlashcardDTO flashcardDTO = FlashcardInteractor.convertFlashcardToDTO(flashcard);
+                FlashcardDataDTO dataDTO = FlashcardInteractor.convertFlashcardDataToDTO(
+                        smartShuffle.flashcardToData.get(flashcard));
+                deckCopy.add(flashcardDTO);
+                flashcardToDataDTO.put(flashcardDTO, dataDTO);
+            }
+            FlashcardDTO lastFlashcardShownDTO = FlashcardInteractor.convertFlashcardToDTO(
+                    smartShuffle.getLastFlashcardShown());
+            return new SmartShuffleDTO(flashcardToDataDTO, deckCopy, lastFlashcardShownDTO);
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Get a CardShuffler entity from its DTO representation.
+     * @param shufflerDTO The target CardShuffler
+     * @return a CardShuffler
+     */
+    public static CardShuffler convertDTOToShuffler(CardShufflerDTO shufflerDTO) {
+        if (shufflerDTO instanceof BasicShuffleDTO basicShuffleDTO) {
+            Map<Flashcard, FlashcardData> flashcardToData = new HashMap<>();
+            List<Flashcard> deckCopy = new ArrayList<>();
+            for (FlashcardDTO flashcardDTO : basicShuffleDTO.getDeckCopy()) {
+                Flashcard flashcard = FlashcardInteractor.convertDTOToFlashcard(flashcardDTO);
+                FlashcardData data = FlashcardInteractor.convertDTOToFlashcardData(
+                        basicShuffleDTO.flashcardToData.get(flashcardDTO));
+                deckCopy.add(flashcard);
+                flashcardToData.put(flashcard, data);
+            }
+            int index = basicShuffleDTO.getIndex();
+            return new BasicShuffle(flashcardToData, deckCopy, index);
+        } else if (shufflerDTO instanceof SmartShuffleDTO smartShuffleDTO) {
+            Map<Flashcard, FlashcardData> flashcardToData = new HashMap<>();
+            LinkedList<Flashcard> deckCopy = new LinkedList<>();
+            for (FlashcardDTO flashcardDTO : smartShuffleDTO.getDeckCopy()) {
+                Flashcard flashcard = FlashcardInteractor.convertDTOToFlashcard(flashcardDTO);
+                FlashcardData data = FlashcardInteractor.convertDTOToFlashcardData(
+                        smartShuffleDTO.flashcardToData.get(flashcardDTO));
+                deckCopy.add(flashcard);
+                flashcardToData.put(flashcard, data);
+            }
+            Flashcard lastFlashcardShown = FlashcardInteractor.convertDTOToFlashcard(
+                    smartShuffleDTO.getLastFlashcardShown());
+            return new SmartShuffle(flashcardToData, deckCopy, lastFlashcardShown);
+        } else {
+            return null;
         }
     }
 

--- a/src/main/java/Sessions/SessionInteractor.java
+++ b/src/main/java/Sessions/SessionInteractor.java
@@ -4,11 +4,6 @@ import Decks.Deck;
 import Decks.DeckDTO;
 import Decks.DeckInteractor;
 import Flashcards.*;
-import Sessions.LearningSession;
-import Sessions.PracticeSession;
-import Sessions.StudySession;
-import Sessions.UpdatingShuffler;
-import jdk.incubator.vector.VectorOperators;
 
 import java.util.*;
 

--- a/src/main/java/Sessions/SmartShuffle.java
+++ b/src/main/java/Sessions/SmartShuffle.java
@@ -6,21 +6,23 @@ import Flashcards.Flashcard;
 
 import java.util.HashMap;
 import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
 
 public class SmartShuffle extends CardShuffler implements UpdatingShuffler {
 
     private final LinkedList<Flashcard> deckCopy;
     private Flashcard lastFlashcardShown;
 
-//    /**
-//     * Constructs a new SmartShuffle shuffler using a preexisting map.
-//     * @param flashcardToData A mapping from Flashcard to FlashcardData taken from this shuffler's StudySession.
-//     */
-//    public SmartShuffle(Map<Flashcard, FlashcardData> flashcardToData) {
-//        this.flashcardToData = flashcardToData;
-//        // This turns an ImmutableList, which ToList returns, to a LinkedList.
-//        this.deckCopy = new LinkedList<>(this.flashcardToData.keySet().stream().toList());
-//    }
+    /**
+     * Constructs a new SmartShuffle shuffler using a preexisting map.
+     * @param flashcardToData A mapping from Flashcard to FlashcardData taken from this shuffler's StudySession.
+     */
+    public SmartShuffle(Map<Flashcard, FlashcardData> flashcardToData) {
+        this.flashcardToData = flashcardToData;
+        // This turns an ImmutableList, which ToList returns, to a LinkedList.
+        this.deckCopy = new LinkedList<>(this.flashcardToData.keySet().stream().toList());
+    }
 
     /**
      * Constructs a new SmartShuffle shuffler, initializing an empty mapping using deck.
@@ -34,6 +36,20 @@ public class SmartShuffle extends CardShuffler implements UpdatingShuffler {
         }
 
         this.deckCopy = new LinkedList<>(this.flashcardToData.keySet().stream().toList());
+    }
+
+    /**
+     * Constructs a new SmartShuffle shuffler using a preexisting map.
+     * @param flashcardToData A mapping from Flashcard to FlashcardData taken from this shuffler's StudySession.
+     * @param deckCopy A list of flashcards which were copied from the original deck
+     * @param lastFlashcardShown The last flashcard shown to the user
+     */
+    public SmartShuffle(Map<Flashcard, FlashcardData> flashcardToData, LinkedList<Flashcard> deckCopy,
+                        Flashcard lastFlashcardShown) {
+        this.flashcardToData = flashcardToData;
+        // This turns an ImmutableList, which ToList returns, to a LinkedList.
+        this.deckCopy = deckCopy;
+        this.lastFlashcardShown = lastFlashcardShown;
     }
 
     /**
@@ -63,6 +79,10 @@ public class SmartShuffle extends CardShuffler implements UpdatingShuffler {
 
     public LinkedList<Flashcard> getDeckCopy() {
         return this.deckCopy;
+    }
+
+    public Flashcard getLastFlashcardShown() {
+        return this.lastFlashcardShown;
     }
 
 

--- a/src/main/java/Sessions/SmartShuffle.java
+++ b/src/main/java/Sessions/SmartShuffle.java
@@ -6,7 +6,6 @@ import Flashcards.Flashcard;
 
 import java.util.HashMap;
 import java.util.LinkedList;
-import java.util.List;
 import java.util.Map;
 
 public class SmartShuffle extends CardShuffler implements UpdatingShuffler {

--- a/src/main/java/Sessions/SmartShuffleDTO.java
+++ b/src/main/java/Sessions/SmartShuffleDTO.java
@@ -1,0 +1,30 @@
+package Sessions;
+
+import Flashcards.Flashcard;
+import Flashcards.FlashcardDTO;
+import Flashcards.FlashcardDataDTO;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+public class SmartShuffleDTO extends CardShufflerDTO {
+
+    private final LinkedList<FlashcardDTO> deckCopy;
+    private final FlashcardDTO lastFlashcardShown;
+
+    public SmartShuffleDTO(Map<FlashcardDTO, FlashcardDataDTO> flashcardToData,
+                           LinkedList<FlashcardDTO> deckCopy, FlashcardDTO lastFlashcardShown) {
+        super(flashcardToData);
+        this.deckCopy = deckCopy;
+        this.lastFlashcardShown = lastFlashcardShown;
+    }
+
+    public LinkedList<FlashcardDTO> getDeckCopy() {
+        return deckCopy;
+    }
+
+    public FlashcardDTO getLastFlashcardShown() {
+        return lastFlashcardShown;
+    }
+}

--- a/src/main/java/Sessions/SmartShuffleDTO.java
+++ b/src/main/java/Sessions/SmartShuffleDTO.java
@@ -1,11 +1,9 @@
 package Sessions;
 
-import Flashcards.Flashcard;
 import Flashcards.FlashcardDTO;
 import Flashcards.FlashcardDataDTO;
 
 import java.util.LinkedList;
-import java.util.List;
 import java.util.Map;
 
 public class SmartShuffleDTO extends CardShufflerDTO {

--- a/src/main/java/Sessions/StudySession.java
+++ b/src/main/java/Sessions/StudySession.java
@@ -11,21 +11,8 @@ import java.util.Map;
  */
 public abstract class StudySession {
     protected Deck deck;
-    protected String name;
     // cardshuffler holds the strategy in how we choose the next card
     protected CardShuffler cardShuffler;
-
-    /**
-     * Constructs a new StudySession with the given deck, name, and cardShuffler
-     * @param deck The deck that this StudySession will be based upon
-     * @param name The string name of this StudySession
-     * @param cardShuffler The CardShuffler that this StudySession will use to get Flashcards
-     */
-    public StudySession(Deck deck, String name, CardShuffler cardShuffler) {
-        this.deck = deck;
-        this.name = name;
-        this.cardShuffler = cardShuffler;
-    }
 
     /**
      * Constructs a StudySession with given deck and cardShuffler
@@ -34,7 +21,6 @@ public abstract class StudySession {
      */
     public StudySession(Deck deck, CardShuffler cardShuffler) {
         this.deck = deck;
-        this.name = "Untitled";
         this.cardShuffler = cardShuffler;
     }
 
@@ -44,6 +30,14 @@ public abstract class StudySession {
      */
     public CardShuffler getCardShuffler() {
         return this.cardShuffler;
+    }
+
+    /**
+     * Returns this StudySession's deck.
+     * @return This StudySession's deck
+     */
+    public Deck getDeck() {
+        return this.deck;
     }
 
      /**

--- a/src/main/java/Sessions/StudySessionDTO.java
+++ b/src/main/java/Sessions/StudySessionDTO.java
@@ -1,6 +1,5 @@
 package Sessions;
 
-import Decks.Deck;
 import Decks.DeckDTO;
 
 public abstract class StudySessionDTO {

--- a/src/main/java/Sessions/StudySessionDTO.java
+++ b/src/main/java/Sessions/StudySessionDTO.java
@@ -1,0 +1,23 @@
+package Sessions;
+
+import Decks.Deck;
+import Decks.DeckDTO;
+
+public abstract class StudySessionDTO {
+
+    private final DeckDTO deckDTO;
+    private final CardShufflerDTO cardShufflerDTO;
+
+    public StudySessionDTO(DeckDTO deckDTO, CardShufflerDTO cardShufflerDTO) {
+        this.deckDTO = deckDTO;
+        this.cardShufflerDTO = cardShufflerDTO;
+    }
+
+    public DeckDTO getDeckDTO() {
+        return deckDTO;
+    }
+
+    public CardShufflerDTO getCardShufflerDTO() {
+        return cardShufflerDTO;
+    }
+}

--- a/src/main/java/Sessions/TestSession.java
+++ b/src/main/java/Sessions/TestSession.java
@@ -5,15 +5,31 @@ import Decks.Deck;
 public class TestSession extends StudySession {
 
     private final int length;
-    private int numCorrect = 0; // the number of times the user guessed the back of the card correctly
+    private int cardsSeen;
+    private int numCorrect; // the number of times the user guessed the back of the card correctly
+
+    /**
+     * Construct a new TestSession
+     * @param deck A deck that will be bound to this TestSession.
+     * @param length How many cards in total will be shown by this session.
+     */
+    public TestSession(Deck deck, int length) {
+        super(deck, new BasicShuffle(deck));
+        this.length = length;
+        this.cardsSeen = 0;
+        this.numCorrect = 0;
+    }
 
     /**
      * Construct a new TestSession
      * @param deck A deck that will be bound to this TestSession.
      */
-    public TestSession(Deck deck, int length) {
-        super(deck, new BasicShuffle(deck));
+    public TestSession(Deck deck, CardShuffler cardShuffler, int length, int cardsSeen, int numCorrect) {
+        super(deck, cardShuffler);
         this.length = length;
+        this.cardShuffler = cardShuffler;
+        this.cardsSeen = cardsSeen;
+        this.numCorrect = numCorrect;
     }
 
     /**
@@ -28,6 +44,20 @@ public class TestSession extends StudySession {
      */
     public void incrementNumCorrect() {
         this.numCorrect++;
+    }
+
+    /**
+     * @return the number of flashcards seen by the user in total during this session.
+     */
+    public int getCardsSeen() {
+        return this.cardsSeen;
+    }
+
+    /**
+     * Increment the counter for the number of flashcards seen by the user in total during this session.
+     */
+    public void incrementCardsSeen() {
+        this.cardsSeen++;
     }
 
     /**

--- a/src/main/java/Sessions/TestSessionDTO.java
+++ b/src/main/java/Sessions/TestSessionDTO.java
@@ -1,0 +1,29 @@
+package Sessions;
+
+import Decks.DeckDTO;
+
+public class TestSessionDTO extends StudySessionDTO {
+
+    private final int length;
+    private final int cardsSeen;
+    private final int numCorrect;
+
+    public TestSessionDTO(DeckDTO deckDTO, CardShufflerDTO cardShufflerDTO, int length, int cardsSeen, int numCorrect) {
+        super(deckDTO, cardShufflerDTO);
+        this.length = length;
+        this.cardsSeen = cardsSeen;
+        this.numCorrect = numCorrect;
+    }
+
+    public int getLength() {
+        return length;
+    }
+
+    public int getCardsSeen() {
+        return cardsSeen;
+    }
+
+    public int getNumCorrect() {
+        return numCorrect;
+    }
+}


### PR DESCRIPTION
This PR removes all references to Entities from the Controllers, instead replacing them with a simple Data Transfer Object representation. 

A significant change for the UI implementation would be the requirement that the Controllers "select" which item that they will work on before every action, rather than being able to simply pass in an object of its choosing. I'm tired right now so I may take another look at this system in the future.

Due to the reliance on mutation for our previous implementation of the Controllers, many changes had to be made to ensure that the same objects internally were being mutated as the copy specified from the Controller. I have done a bit of testing on the CLI demo, and it seems to work as before, at least for the parts which are functional in the CLI.

Note that the database has yet to be modified to fit the changes in the PR. 

Closes #31.